### PR TITLE
Add getpinfo syscall and ps user command to xv6

### DIFF
--- a/G17_Project1_xv6CustomizeSystemCalls/Makefile
+++ b/G17_Project1_xv6CustomizeSystemCalls/Makefile
@@ -145,6 +145,7 @@ UPROGS=\
 	$U/_logstress\
 	$U/_forphan\
 	$U/_dorphan\
+	$U/_ps\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/G17_Project1_xv6CustomizeSystemCalls/kernel/defs.h
+++ b/G17_Project1_xv6CustomizeSystemCalls/kernel/defs.h
@@ -101,6 +101,7 @@ void            yield(void);
 int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
+int             kgetpinfo(uint64);
 
 // swtch.S
 void            swtch(struct context*, struct context*);

--- a/G17_Project1_xv6CustomizeSystemCalls/kernel/pinfo.h
+++ b/G17_Project1_xv6CustomizeSystemCalls/kernel/pinfo.h
@@ -1,0 +1,13 @@
+// shared structure for the getpinfo() system call.
+// this captures a snapshot of all active processes from the process table.
+
+
+#define MAX_PROCS 64 // must match NPROC in param.h
+
+struct pinfo {
+  int pid[MAX_PROCS];       // process ID
+  int state[MAX_PROCS];     // procstate enum (UNUSED=0 … ZOMBIE=5)
+  uint64 sz[MAX_PROCS];     // memory size
+  char name[MAX_PROCS][16]; // process name
+  int num_procs;            // number of active entries filled
+};

--- a/G17_Project1_xv6CustomizeSystemCalls/kernel/proc.c
+++ b/G17_Project1_xv6CustomizeSystemCalls/kernel/proc.c
@@ -4,6 +4,7 @@
 #include "riscv.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "pinfo.h"
 #include "defs.h"
 
 struct cpu cpus[NCPU];
@@ -687,4 +688,30 @@ procdump(void)
     printf("%d %s %s", p->pid, state, p->name);
     printf("\n");
   }
+}
+
+int
+kgetpinfo(uint64 addr)
+{
+  struct pinfo pi;
+  struct proc *p;
+  int i = 0;
+
+  for(p = proc; p < &proc[NPROC]; p++) {
+    acquire(&p->lock);
+    if(p->state != UNUSED) {
+      pi.pid[i] = p->pid;
+      pi.state[i] = (int)p->state;
+      pi.sz[i] = p->sz;
+      safestrcpy(pi.name[i], p->name, sizeof(p->name));
+      i++;
+    }
+    release(&p->lock);
+  }
+
+  pi.num_procs = i;
+
+  if(copyout(myproc()->pagetable, addr, (char*)&pi, sizeof(pi)) < 0)
+    return -1;
+  return 0;
 }

--- a/G17_Project1_xv6CustomizeSystemCalls/kernel/syscall.c
+++ b/G17_Project1_xv6CustomizeSystemCalls/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_getpinfo(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_getpinfo] sys_getpinfo,
 };
 
 void

--- a/G17_Project1_xv6CustomizeSystemCalls/kernel/syscall.h
+++ b/G17_Project1_xv6CustomizeSystemCalls/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_getpinfo 22

--- a/G17_Project1_xv6CustomizeSystemCalls/kernel/sysproc.c
+++ b/G17_Project1_xv6CustomizeSystemCalls/kernel/sysproc.c
@@ -107,3 +107,11 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+uint64
+sys_getpinfo(void)
+{
+  uint64 addr;
+  argaddr(0, &addr);
+  return kgetpinfo(addr);
+}

--- a/G17_Project1_xv6CustomizeSystemCalls/user/ps.c
+++ b/G17_Project1_xv6CustomizeSystemCalls/user/ps.c
@@ -1,0 +1,42 @@
+// user-space program to display process table via getpinfo()
+// Usage: ps
+
+#include "kernel/types.h"
+#include "user/user.h"
+
+// Must match kernel/pinfo.h exactly
+#define MAX_PROCS 64
+struct pinfo {
+  int pid[MAX_PROCS];
+  int state[MAX_PROCS];
+  uint64 sz[MAX_PROCS];
+  char name[MAX_PROCS][16];
+  int num_procs;
+};
+
+// State names matching enum procstate in proc.h
+static char *states[] = {
+    "UNUSED", "USED", "SLEEPING", "RUNNABLE", "RUNNING", "ZOMBIE",
+};
+
+int main(void) {
+  struct pinfo pi;
+
+  if (getpinfo(&pi) < 0) {
+    fprintf(2, "ps: getpinfo failed\n");
+    exit(1);
+  }
+
+  printf("PID STATE SIZE(B) NAME\n");
+  printf("--- ----- ------- ----\n");
+
+  for (int i = 0; i < pi.num_procs; i++) {
+    char *state = "???";
+    int s = pi.state[i];
+    if (s >= 0 && s < 6)
+      state = states[s];
+    printf("%d %s %d %s\n", pi.pid[i], state, (int)pi.sz[i], pi.name[i]);
+  }
+
+  exit(0);
+}

--- a/G17_Project1_xv6CustomizeSystemCalls/user/user.h
+++ b/G17_Project1_xv6CustomizeSystemCalls/user/user.h
@@ -1,6 +1,7 @@
 #define SBRK_ERROR ((char *)-1)
 
 struct stat;
+struct pinfo;
 
 // system calls
 int fork(void);
@@ -24,6 +25,7 @@ int getpid(void);
 char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
+int getpinfo(struct pinfo*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/G17_Project1_xv6CustomizeSystemCalls/user/usys.pl
+++ b/G17_Project1_xv6CustomizeSystemCalls/user/usys.pl
@@ -42,3 +42,4 @@ entry("getpid");
 entry("sbrk");
 entry("pause");
 entry("uptime");
+entry("getpinfo");


### PR DESCRIPTION
#  getpinfo and ps

closes #12 

## What this does

- `getpinfo` collects a snapshot of active processes from the kernel process table.
- `ps` calls `getpinfo` and prints process information in user space.


## Data returned by getpinfo
The syscall fills a `struct pinfo` containing:

- `pid`: process IDs
- `state`: process states (UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE)
- `sz`: process memory size in bytes
- `name`: process names
- `num_procs`: number of valid entries filled

## User command
Run from xv6 shell:

`ps`

Example output:
```bash
PID STATE SIZE(B) NAME
--- ----- ------- ----
1 SLEEPING 16384 init
2 SLEEPING 20480 sh
3 RUNNING 16384 ps
```
